### PR TITLE
(not yet working)

### DIFF
--- a/deployments/modal_serve.py
+++ b/deployments/modal_serve.py
@@ -1,0 +1,38 @@
+"""Example LangChain Plugin deployment on Modal."""
+import os
+from pathlib import Path
+import modal
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+client = modal.Client()
+# Infer the deployment URL
+_PREV_SET = "PUBLIC_API_URL" in os.environ
+_LABEL = "langchain-plugin"
+modal_workspace = os.environ["MODAL_WORKSPACE"]  # TODO: get this programatically
+os.environ["PUBLIC_API_URL"] = f"https://{modal_workspace}--{_LABEL}.modal.run"
+if _PREV_SET:
+    logging.warning(
+        "PUBLIC_API_URL is ignored when serving on Modal."
+        f" Newly set to {os.environ['PUBLIC_API_URL']}"
+    )
+from app.main import app, REQUIRED_ENV_VARS
+
+_IMAGE = (
+    modal.Image.debian_slim()
+    .env({var: os.environ[var] for var in REQUIRED_ENV_VARS})
+    .from_dockerfile(
+        Path(__file__).parents[1] / "Dockerfile",
+    )
+    )
+    # .poetry_install_from_file("pyproject.toml")
+)
+# stub = modal.aio.AioStub()
+stub = modal.stub.AioStub()
+
+
+@stub.asgi(image=_IMAGE, label=_LABEL)
+def fastapi_app():
+    """FastAPI app."""
+    return app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ black = { version="^23.1.0", extras=["jupyter"] }
 ruff = "^0.0.255"
 
 
+
+[tool.poetry.group.modal.dependencies]
+modal-client = "^0.48.1750"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Draft of modal work thus far. .poetry_install_from_file("pyproject.toml") works for deps but doesn't add the retrieval paths. May just use docker like fly. Will revisit in 2 hours